### PR TITLE
Update PostgreSQL Interface

### DIFF
--- a/databases/Postgres.cs
+++ b/databases/Postgres.cs
@@ -7,7 +7,7 @@ using KDG.Database.Interfaces;
 
 namespace KDG.Database;
 
-public class PostgreSQL : DML.PostgreSQL, IDatabase<NpgsqlConnection,NpgsqlTransaction> {
+public class PostgreSQL : DML.PostgreSQL {
     public string ConnectionString { get; set; }
     public PostgreSQL(string connectionString) {
         this.ConnectionString = connectionString;

--- a/dml/Postgres.cs
+++ b/dml/Postgres.cs
@@ -1,6 +1,8 @@
+using KDG.Database.Interfaces;
+using Npgsql;
 namespace KDG.Database.DML;
 
-public interface PostgreSQL {
+public interface PostgreSQL : IDatabase<NpgsqlConnection,NpgsqlTransaction> {
     public Task Insert<T>(Npgsql.NpgsqlTransaction transaction, InsertConfig<T> config);
     public Task Update<T>(Npgsql.NpgsqlTransaction transaction, UpdateConfig<T> config);
     public Task Upsert<T>(Npgsql.NpgsqlTransaction transaction, UpsertConfig<T> config);


### PR DESCRIPTION
Currently when I register an instance of KDG.Database.DML.PostgreSQL, it is not recognized as an implementation of IDatabase, even though the only implementation of PostgreSQL provided also implements the IDatabase interface. I propose we make implementing IDatabase a strict requirement of all PostgreSQL implementations so that they satisfy IDatabase requirements during dependency injection (e.g. for unit tests)